### PR TITLE
Upgrade to omniauth-oauth2 1.4.0 and fix callback url issue

### DIFF
--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -25,7 +25,7 @@ module OmniAuth
 
         options.client_id = provider.client_id
         options.client_secret = provider.client_secret
-        options.tenant_id = 
+        options.tenant_id =
           provider.respond_to?(:tenant_id) ? provider.tenant_id : 'common'
 
         options.authorize_params.domain_hint = provider.domain_hint if provider.respond_to?(:domain_hint) && provider.domain_hint
@@ -53,6 +53,9 @@ module OmniAuth
         }
       end
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
 
       def raw_info
         # it's all here in JWT http://msdn.microsoft.com/en-us/library/azure/dn195587.aspx

--- a/omniauth-azure-oauth2.gemspec
+++ b/omniauth-azure-oauth2.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'omniauth', '~> 1.0'
   gem.add_dependency 'jwt', '~> 1.0'
 
-  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.1'
+  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.4'
 
   gem.add_development_dependency 'rspec', '>= 2.14.0'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Omniauth defines callback URL as:

  full_host + script_name + callback_path + query_string

(via https://github.com/intridea/omniauth/blob/1cc1cf4b2821a7d2a4a376a5ca93c61b6bd8b5f1/lib/omniauth/strategy.rb#L432)

Omniauth-oauth2 declines to override this after
https://github.com/intridea/omniauth-oauth2/pull/70

So, this library is overriding omniauth itself, and
omitting the query string from the callback_url (which
Azure AD seems to have trouble with).
